### PR TITLE
Revise CPI time series for Berlin 1996

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ That's it. Variables gdp and income will now be in values as of 2010.
 
 * Germany, Consumer Price Index
     * Provided by the [Federal Statistical Office](http://www.destatis.de/)
-    * [Verbraucherpreisindex für Deutschland - Lange Reihen ab 1948](https://www.destatis.de/DE/Themen/Wirtschaft/Preise/Verbraucherpreisindex/Publikationen/Downloads-Verbraucherpreise/verbraucherpreisindex-lange-reihen-xlsx-5611103.xlsx)
+    * [Verbraucherpreisindex für Deutschland - Lange Reihen ab 1948, version 13.08.2020](https://www.destatis.de/DE/Themen/Wirtschaft/Preise/Verbraucherpreisindex/Publikationen/Downloads-Verbraucherpreise/verbraucherpreisindex-lange-reihen-xlsx-5611103.xlsx)
     * 1949-1962: Index der Einzelhandelspreise (based on West Germany only)
     * 1963-1991: Preisindex für die Lebenshaltung, Alle privaten Haushalte (based on West Germany only)
     * 1992-2019: Verbraucherpreisindex
     * 2020: assumed to equal CPI inflation rate of previous year
 * Berlin, Germany, Consumer Price Index
-    * Provided by the [Federal Statistical Office](http://www.destatis.de/) and the [Statistical Office Berlin](http://www.statistik-berlin-brandenburg.de/)
-    * [GENESIS-Online Datenbank](https://www-genesis.destatis.de/genesis/online), Tabellencode 61111-0010, [Verbraucherpreisindex in Berlin 1991 bis 2017 nach Abteilungen](https://www.statistik-berlin-brandenburg.de/statistiken/langereihen/dateien/Verbraucherpreise.xlsx)
-    * 1992-1995: Verbraucherpreisindex (Statistical Office Berlin)
+    * Provided by the [Federal Statistical Office](http://www.destatis.de/) and the [Statistical Office Berlin-Brandenburg](http://www.statistik-berlin-brandenburg.de/)
+    * [GENESIS-Online Datenbank](https://www-genesis.destatis.de/genesis/online), Tabellencode 61111-0010, downloaded 13.08.2020, [Verbraucherpreisindex in Berlin 1991 bis 2019 nach Abteilungen, version 23.07.2020](https://www.statistik-berlin-brandenburg.de/statistiken/langereihen/dateien/Verbraucherpreise.xlsx)
+    * 1992-1995: Verbraucherpreisindex (Statistical Office Berlin-Brandenburg)
     * 1996-2019: Verbraucherpreisindex (Federal Statistical Office)
     * 2020: assumed to equal CPI inflation rate of previous year
 

--- a/uprateit.ado
+++ b/uprateit.ado
@@ -21,6 +21,7 @@
  * 2018-12-02   Add time series for Berlin, Germany (CPI) 1992-2018 (v0.2.4)
  * 2019-02-05   Extend time series for Germany (CPI) until 2019 (v0.2.5)
  * 2019-05-07   Use built-in ds command instead of isvar ado (v0.2.6)
+ * 2020-04-03   Revise CPI time series for Germany&Berlin (v0.2.7)
  * 
  *
  * Copyright (C) 2014-2019 Max Löffler <max.loeffler@uni-koeln.de>

--- a/uprateit.ado
+++ b/uprateit.ado
@@ -1,4 +1,4 @@
-*! version 0.2.7, 03apr2020, Max Loeffler <m.loeffler@maastrichtuniversity.nl>
+*! version 0.2.8, 13aug2020, Max Loeffler <m.loeffler@maastrichtuniversity.nl>
 /**
  * UPRATEIT - UPRATE MONETARY VARIABLES ACCORDING TO INFLATION INDICIES
  * 
@@ -22,6 +22,7 @@
  * 2019-02-05   Extend time series for Germany (CPI) until 2019 (v0.2.5)
  * 2019-05-07   Use built-in ds command instead of isvar ado (v0.2.6)
  * 2020-04-03   Revise CPI time series for Germany&Berlin (v0.2.7)
+ * 2020-08-13   Revise CPI time series for Berlin 1996 (v0.2.8)
  * 
  *
  * Copyright (C) 2014-2019 Max Löffler <max.loeffler@uni-koeln.de>

--- a/uprateit_create_table.ado
+++ b/uprateit_create_table.ado
@@ -1,4 +1,4 @@
-*! version 0.2.7, 03apr2020, Max Loeffler <m.loeffler@maastrichtuniversity.nl>
+*! version 0.2.8, 13aug2020, Max Loeffler <m.loeffler@maastrichtuniversity.nl>
 /**
  * UPRATEIT - UPRATE MONETARY VARIABLES ACCORDING TO INFLATION INDICIES
  * 
@@ -111,7 +111,7 @@ program define uprateit_create_table
                         1993,    4.9  \ ///
                         1994,    2.4  \ ///
                         1995,    1.8  \ ///
-                        1996,    0.9  \ ///
+                        1996,    1.2  \ ///
                         1997,    1.4  \ ///
                         1998,    0.4  \ ///
                         1999,    0.0  \ ///


### PR DESCRIPTION
This fixes (or updates) the CPI time series for de-be for 1996 and adds release dates or retrieval dates to the sources used. 

README.md says for Berlin:

> 1996-2019: Verbraucherpreisindex (Federal Statistical Office)

Data taken from GENESIS-Online Datenbank (today), Tabellencode 61111-0010 gives me a different value for 1996. I get (78.7/77.8-1)*100 ≈ 1.2, not 0.9.

The value of 0.9 can also not be found in https://www.statistik-berlin-brandenburg.de/statistiken/langereihen/dateien/Verbraucherpreise.xlsx (which has 1.2 for 1996 too).

It might of course be that the data sources were revised by the Statistical Office. I therefore add release dates or retrieval dates to the readme file.
